### PR TITLE
Vulkan native stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 # Build and run output
 build/
 builds/
+diagnostic-logs-backup/
+dlss5-runtime-v*/
 *.log
 *.ppm
 *.raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.1 — Native Vulkan game stability
 
-This fork hardens the experimental Vulkan route for native games, validated on Detroit: Become
+This release hardens the experimental Vulkan route for native games, validated on Detroit: Become
 Human and DOOM Eternal with ReShade 6.8.0.2155 and an AMD Radeon RX 9070 XT.
 
 - Link the add-on with the static MSVC runtime (`/MT`). Detroit ships older `msvcp140.dll` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.4.1 — Native Vulkan game stability
+
+This fork hardens the experimental Vulkan route for native games, validated on Detroit: Become
+Human and DOOM Eternal with ReShade 6.8.0.2155 and an AMD Radeon RX 9070 XT.
+
+- Link the add-on with the static MSVC runtime (`/MT`). Detroit ships older `msvcp140.dll` and
+  `vcruntime140.dll` files beside its executable; a `/MD` build registered with ReShade but failed
+  during `DllMain`. The static build has no dependency on those private runtime copies.
+- Validate the Vulkan present queue and immediate command list before use. An unsupported async
+  queue now skips safely instead of dereferencing a null command-list pointer.
+- Preserve both `DISABLE_VK_LAYER_reshade_1` and `_2` while creating the private Vulkan discovery
+  instance. This supports the renamed kill switch needed by DOOM's launcher without recursively
+  entering ReShade.
+- Create the private D3D12 crossing texture in `COPY_DEST`, matching its first operation.
+- Recreate a D3D12 allocator/command-list pair after `Reset` or `Close` failure so one bad recording
+  cannot poison a work slot for the remainder of the process.
+- Fully retire swapchain-sized Vulkan state: wait for the host device, release imported images,
+  invalidate dimensions and readiness, and rebuild all crossings even when the new swapchain has
+  the same size and format.
+- Strengthen the Vulkan fast path so it also requires live imported images and D3D12 resources.
+
+Live validation after the fixes:
+
+| Host | Frames | Swapchain/toggle result | Skips | Result |
+|---|---:|---|---:|---|
+| Detroit: Become Human | 9,240 | repeated toggles and two full rebuilds | 0 | stable |
+| DOOM Eternal | 3,600 | repeated alt-tabs and about ten full rebuilds | 1 | stable |
+
+Both runs reported a non-zero, detail-correlated residual. Neither log contains command-list
+`Close`/`Reset` failures, device loss or a bridge stand-down after the fixes. Vulkan depth remains
+an explicit future task: the current route feeds colour and estimated motion.
+
 ## v0.4.0 — Vulkan, D3D12, and a trail that was not the network's fault
 
 Requires the pinned **v0.2.17** runtime; v0.2.14 is refused. `dlssnr_amd_pass2.dll` and

--- a/README.md
+++ b/README.md
@@ -2,21 +2,27 @@
 
 **THIS IS A PROOF-OF-CONCEPT, NOT EVEN CLOSE TO FINAL VERSION, FORK IT, SHARE IT, LETS GROW TOGETHER**
 
-## v0.4.0
+## v0.4.1
 
-**One package now.** There is no longer a separate Vulkan build to choose between. The Vulkan
-transport is compiled in and does nothing at all on a D3D11 or D3D12 game — it hooks one import
-table entry, and a game that does not import Vulkan has none. Measured, not assumed: the same
-binary ran NFS 2015 on D3D11, GTA V Enhanced on D3D12 and RPCS3 on Vulkan.
+**Native Vulkan games are now part of the validation set.** The Vulkan route now rejects
+non-graphics present queues safely, rebuilds its imported images across swapchain recreation, and
+recovers its D3D12 work slots after a failed reset or close. The same binary completed 9,240 frames
+in Detroit: Become Human without a skip and 3,600 frames in DOOM Eternal with one transient skip
+during a scale change, followed by automatic recovery.
+
+**One package covers every supported renderer.** There is no separate Vulkan build to choose
+between. The Vulkan transport is compiled in and does nothing on a D3D11 or D3D12 game — it hooks
+one import-table entry, and a game that does not import Vulkan has none. The add-on now links the
+MSVC runtime statically too, so a game's private, older Visual C++ DLLs cannot prevent it loading.
 
 **This release requires the pinned v0.2.17 runtime.** v0.2.14 is refused. If you are updating
 from v0.3.0, you must replace `dlssnr_amd_pass1.dll` and `dlssnr_on_amd_weights.bin` — see
 [the three files](#the-three-files) for the hashes. Delete `dlssnr_amd_pass2.dll` and
 `pass3.dll` if you still have them; nothing has used them for two releases.
 
-**Vulkan is experimental, and narrowly so — read [Case 3](#case-3--vulkan-rpcs3-experimental)
-before trying it.** It works on RPCS3 and is known not to work on PCSX2, for a reason that is
-structural rather than a bug.
+**Vulkan is still experimental — read [Case 3](#case-3--vulkan-experimental) before trying it.**
+It is validated on RPCS3, Detroit: Become Human and DOOM Eternal. It is known not to work on PCSX2,
+for a reason that is structural rather than a bug.
 
 **FSR upscaling is still not implemented**, and this release stops calling it upcoming. The
 measurement that closed it is in [Stuff I didn't get to](#stuff-i-didnt-get-to).
@@ -46,11 +52,14 @@ Run so far, on an RX 9070 XT:
 | **Need for Speed 2015** | D3D11 | The worked example in Case 1. 1,205 frames on the v0.4.0 build with one skip and no failures. |
 | **GTA V Enhanced** | D3D12 | 23,663 frames, no failures. The degraded case: an add-on is shown nothing but the swapchain, so there is no depth and no game motion. |
 | **RPCS3** | Vulkan | 1,879 frames on the v0.4.0 build, after 3,360 on the previous one. Experimental — see Case 3. |
+| **Detroit: Become Human** | Vulkan | 9,240 frames, no skips, repeated toggles and two complete swapchain rebuilds on v0.4.1. |
+| **DOOM Eternal** | Vulkan | 3,600 frames, one transient skip during a scale change, repeated Alt+Tab rebuilds on v0.4.1. Requires a graphics present queue; see Case 3. |
 
 **Anything else is untested, not unsupported.** There is no whitelist and nothing to compile:
-point ReShade at any D3D11 or D3D12 game, drop the same three files beside it, and it runs. The
-status line will just say *uncatalogued target*, which changes nothing. If a game does something
-odd, the probe in `src/probe` dumps what it actually exposes.
+point ReShade at a D3D11, D3D12 or compatible Vulkan host, drop the same three files beside it, and
+it runs. A Vulkan host must import `vkCreateDevice` by name and present on a graphics-capable queue.
+The status line will just say *uncatalogued target*, which changes nothing. If a game does
+something odd, the probe in `src/probe` dumps what it actually exposes.
 
 Discord: https://discord.gg/wYhvS3JSHM — for DLSS 5 in general, not a support channel for this.
 
@@ -60,7 +69,7 @@ Discord: https://discord.gg/wYhvS3JSHM — for DLSS 5 in general, not a support 
 [the three files](#the-three-files) by hand, then your case:
 **[DirectX 11 game](#case-1--directx-11-games)**,
 **[PS2 emulator](#case-2--ps2-emulator-pcsx2)** or
-**[Vulkan / RPCS3](#case-3--vulkan-rpcs3-experimental)**. No compiler needed.
+**[Vulkan](#case-3--vulkan-experimental)**. No compiler needed.
 **Broken?** → [Troubleshooting](#troubleshooting), keyed by what you see on screen.
 **Changing the code?** → [Building it yourself](#building-it-yourself-optional).
 
@@ -198,20 +207,25 @@ read, and the depth it does have is faint. That is a property of the console, no
 
 ---
 
-## Case 3 — Vulkan (RPCS3), experimental
+## Case 3 — Vulkan, experimental
 
-Read this before trying it. The Vulkan route works, and it works narrowly.
+Read this before trying it. The Vulkan route works in emulators and native games, within two hard
+requirements imposed by the interop design.
 
 **It needs a host that imports `vkCreateDevice` statically, by name.** A Vulkan device has to be
 created with the external-memory and external-semaphore extensions or it can never import a D3D12
 texture, and once the device exists that cannot be fixed. So the add-on patches one entry in the
 host's import table and adds the seven extensions on the way through.
 
-A program that resolves Vulkan dynamically has no such entry, and there is nothing to patch.
+A program that resolves Vulkan dynamically has no such entry, and there is nothing to patch. The
+queue used for presentation must also support graphics commands; the add-on refuses an async-only
+present queue instead of trying to record a copy through a null immediate command list.
 
 | Host | `vulkan-1.dll` in its import table | Result |
 |---|---|---|
 | **RPCS3** | yes | Works. 1,879 frames, bridge up, full round trip. |
+| **Detroit: Become Human** | yes | Works. 9,240 frames, no skips, toggle and swapchain-rebuild recovery verified. |
+| **DOOM Eternal** | yes | Works with a graphics present queue. 3,600 frames, one recovered scale-change skip and repeated Alt+Tab rebuilds. |
 | **PCSX2** | no — resolves through `vkGetInstanceProcAddr` | Stands down and leaves the picture alone. |
 
 When it stands down it says so, in `dlss5-neural.log`, in those words:
@@ -234,10 +248,17 @@ to the add-on — which may mean the emulator does not make one, or that ReShade
 them on Vulkan. Neither has been separated, and neither changes the outcome.
 
 **Setup.** ReShade's Vulkan support is a global layer, not a proxy DLL, and it only applies to
-programs listed in `C:\ProgramData\ReShade\ReShadeApps.ini`. Run the ReShade installer against
-`rpcs3.exe` and pick **Vulkan**; that writes the entry. Then drop the three files next to
-`rpcs3.exe`. If you also have a proxy DLL (`dxgi.dll`, `d3d11.dll`) in the same folder from a
-previous install, remove it: two ReShade instances in one process is not a supported arrangement.
+programs listed in `C:\ProgramData\ReShade\ReShadeApps.ini`. Run the ReShade installer against the
+game or emulator executable and pick **Vulkan**; that writes the entry. Then drop the three files
+next to that executable. If you also have a proxy DLL (`dxgi.dll`, `d3d11.dll`) in the same folder
+from a previous install, remove it: two ReShade instances in one process is not a supported
+arrangement.
+
+DOOM Eternal normally presents from an async queue. Set `r_presentFromAsync "0"` so presentation
+uses a graphics-capable queue; otherwise v0.4.1 logs the unsupported queue and leaves the game's
+image untouched. A resize, display-mode change or Alt+Tab may recreate the swapchain. The Vulkan
+bridge now retires and rebuilds every imported image in that case, including when the new
+swapchain has the same dimensions and format.
 
 ---
 
@@ -270,6 +291,7 @@ The defaults are fine to start with. The status line says whether it is really r
 |---|---|
 | Add-on isn't in the Add-ons tab at all | `ReShade.ini` has `DisabledAddons=dlss5 neural@dlss5-neural.addon64` under `[ADDON]`. ReShade writes that line if you ever untick the add-on, and then it never loads again, with no error anywhere. Clear it. |
 | Status says the API is wrong | D3D11, D3D12 and Vulkan are all accepted by the one package. OpenGL has no route. Check per-game renderer overrides -- they beat the global setting silently. |
+| Vulkan log says the present queue is not graphics-capable | The host presented from an async-only queue, which cannot record the bridge copy. If this is DOOM Eternal, set `r_presentFromAsync "0"`, restart the game and try again. |
 | `HIP: amdhip64_7.dll failed to load` | HIP 7 isn't installed. HIP 6 doesn't count. |
 | `hash mismatch; refused` | Wrong `dlssnr_amd_pass1.dll`. Compare against `tools/SHA256SUMS.txt`. The refusal is deliberate — the alternative is a hang. |
 | Game dies with `887A0005` / device removed | `DXGI_ERROR_DEVICE_REMOVED`, from a Windows TDR. See [the engine ini](#the-engine-ini). |
@@ -431,6 +453,9 @@ cd dlss5-neural-amd
 powershell -ExecutionPolicy Bypass -File .\build.ps1 -Target neural
 ```
 
+The release target links the C/C++ runtime statically (`/MT`). The resulting add-on does not rely
+on `msvcp140.dll` or `vcruntime140.dll` beside the game executable.
+
 Note the `-ExecutionPolicy Bypass`. Windows refuses to run downloaded `.ps1` files by default, so
 plain `.\build.ps1` usually fails with *"cannot be loaded because running scripts is disabled on
 this system"*. That message is Windows, not this project. The line above sidesteps it for that
@@ -468,18 +493,22 @@ so if the badge is green the repository builds as-is.
 The network takes four inputs: colour, depth, motion and exposure. **Which of them it gets is
 decided by the renderer, and that is the single most important thing on this page.**
 
-Measured with the probe in `src/probe`, same game, same frame, only the renderer changed:
+The D3D11 and D3D12 columns were measured with the probe in `src/probe`, using the same game and
+frame with only the renderer changed. The Vulkan column describes the current transport route:
 
-| | on **D3D12** | on **D3D11** |
-|---|---|---|
-| render targets ReShade shows the add-on | **2** | **8** |
-| depth | none | the game's own depth target |
-| colour | the presented back buffer | available at render resolution |
+| | on **D3D12** | on **D3D11** | on **Vulkan** |
+|---|---|---|---|
+| render targets ReShade shows the add-on | **2** | **8** | presented image through the Vulkan bridge |
+| depth | none | the game's own depth target | none |
+| motion | estimated from colour | game's velocity target when available | estimated from colour |
+| colour | the presented back buffer | available at render resolution | the presented image |
 
 On D3D12 an add-on sees the swapchain and nothing else — `bind_render_targets_and_depth_stencil`
 fires **zero** times in 600 frames, with or without also subscribing to the draw events, both
 tried and both measured. That is a property of the API path, not of any game. So on D3D12 the
-network runs on colour alone.
+network runs on colour and estimated motion. Vulkan currently follows the same guide policy after
+the presented image crosses into the private D3D12 device; `Depth=1` does not create a Vulkan depth
+source.
 
 **On D3D11 it gets depth and motion too.** The AMD network runtime is D3D12, so the add-on builds
 its own D3D12 device on the game's adapter and carries textures across through shared resources
@@ -612,14 +641,16 @@ None of this is settled, it is just where things stand. One card, three programs
   and converted before it crosses; motion comes from the game's own velocity buffer where there
   is one, and from a block-matching estimator where there isn't. Still open: nobody has read the
   guide probe **during real gameplay**, only on menus, where flat depth and zero motion are what
-  you would expect anyway. That reading is the next thing worth having.
+  you would expect anyway. Vulkan still has estimated motion only; exposing a reliable Vulkan
+  depth source remains open.
 * Exposure. The fourth slot of the network's input packet is still never filled, and it has
   never been shown that the engine reads it.
 * The network itself. DLSS-NR is a denoiser for modern ray traced stuff. Something built for
   restoration or upscaling old content would probably fit emulators better, and swapping it
   doesn't mean rewriting everything.
-* More targets. ETS2, PCSX2 and NFS 2015 are the three that have been run. Everything else is
-  simply untried — the add-on does not check what game it is in.
+* More targets. ETS2, PCSX2, NFS 2015, GTA V Enhanced, RPCS3, Detroit: Become Human and DOOM
+  Eternal have been run. Everything else is simply untried — the add-on does not check what game
+  it is in.
 * One card. Everything here is an RX 9070 XT. RDNA3 is untested.
 
 ## Model A/B/C: will not be implemented

--- a/build.ps1
+++ b/build.ps1
@@ -101,7 +101,10 @@ $dll = Join-Path $out $(if ($Exe) { "dlss5-$Target.exe" } else { "dlss5-$Target.
 Push-Location $out
 try {
     # NOMINMAX: without it the max/min macros in windows.h swallow std::max/std::min.
-    & $cl /nologo /utf-8 /std:c++20 /EHsc /O2 /MD /W3 /DNDEBUG /DUNICODE /D_UNICODE /D_CRT_SECURE_NO_WARNINGS `
+    # Link the CRT statically. Some games, including Detroit: Become Human, ship an older
+    # msvcp140.dll beside the executable; /MD lets that private copy override the runtime used
+    # to build the add-on and can make DllMain fail after ReShade has registered the module.
+    & $cl /nologo /utf-8 /std:c++20 /EHsc /O2 /MT /W3 /DNDEBUG /DUNICODE /D_UNICODE /D_CRT_SECURE_NO_WARNINGS `
           /DNOMINMAX /DWIN32_LEAN_AND_MEAN `
           /Fo"$out\" $(if (-not $Exe) { '/LD' }) $src /link $(if (-not $Exe) { '/DLL' }) /OUT:"$dll" `
           user32.lib d3d11.lib d3d12.lib dxgi.lib d3dcompiler.lib bcrypt.lib

--- a/docs/preview-2026-09-10.md
+++ b/docs/preview-2026-09-10.md
@@ -1,4 +1,17 @@
-# Preview 2026-09-10
+# Preview 2026-09-10 (superseded)
+
+> **Historical document.** This preview predates the unified v0.4.0 package and the native Vulkan
+> lifecycle fixes in v0.4.1. The current package supports D3D11, D3D12 and compatible Vulkan hosts;
+> see the root README and CHANGELOG for current installation, limitations and validation results.
+
+## Current status
+
+- There is one add-on package for D3D11, D3D12 and Vulkan.
+- Native Vulkan validation covers Detroit: Become Human and DOOM Eternal in addition to RPCS3.
+- Swapchain rebuilds, repeated toggles and Alt+Tab recovery are covered by the v0.4.1 live runs.
+- Vulkan currently receives colour and estimated motion, but not depth.
+
+## Original preview notes
 
 The same neural fixes are included in both packages. The normal build supports D3D11/D3D12;
 the Vulkan build adds the experimental Vulkan transport and device-creation hook. Install only

--- a/installer/README.md
+++ b/installer/README.md
@@ -34,6 +34,17 @@ The runtime and the weights are **not** embedded and never will be: the weights 
 NVIDIA-derived and the runtime is a third-party build. The user points at the folder they
 unzipped them into.
 
+## Native Vulkan notes
+
+The Vulkan preset supports both emulators and native games, but it only installs this project's
+three files. Install ReShade's full add-on build for the target executable separately and select
+Vulkan so the executable is registered in `C:\ProgramData\ReShade\ReShadeApps.ini`. Do not leave a
+ReShade proxy DLL beside the executable at the same time.
+
+The v0.4.1 add-on validates that presentation uses a graphics-capable queue and rebuilds its
+cross-API resources after a swapchain change. DOOM Eternal users may need to set
+`r_presentFromAsync "0"`; the default async-only presentation route cannot record the bridge copy.
+
 ## Building
 
 ```powershell

--- a/src/neural/neural.cpp
+++ b/src/neural/neural.cpp
@@ -1588,6 +1588,36 @@ void SaveSettings()
 // The adapter comes from the game's own D3D11 device, which BridgeStep1 has already asked. That
 // is the same adapter by construction, and it means no DXGI factory has to be created -- one
 // fewer library to touch, and one fewer chance to disturb the runtime the game is using.
+bool RecreateWorkSlot(UINT slot)
+{
+    if (slot >= State::kRing || g.workDevice == nullptr)
+        return false;
+
+    // A failed Close leaves the list recording and unusable, while an allocator Reset followed by
+    // a failed list Reset leaves the pair out of step. Recreate both so a transient bad recording
+    // cannot poison this ring slot for the rest of the process.
+    g.list[slot].Reset();
+    g.alloc[slot].Reset();
+    const HRESULT allocatorHr = g.workDevice->CreateCommandAllocator(
+        D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&g.alloc[slot]));
+    const HRESULT listHr = SUCCEEDED(allocatorHr)
+                               ? g.workDevice->CreateCommandList(
+                                     0, D3D12_COMMAND_LIST_TYPE_DIRECT, g.alloc[slot].Get(), nullptr,
+                                     IID_PPV_ARGS(&g.list[slot]))
+                               : allocatorHr;
+    const HRESULT closeHr = SUCCEEDED(listHr) ? g.list[slot]->Close() : listHr;
+    if (FAILED(allocatorHr) || FAILED(listHr) || FAILED(closeHr))
+    {
+        Log("bridge: could not recreate work slot %u (allocator 0x%08lX, list 0x%08lX, "
+            "close 0x%08lX).", slot, allocatorHr, listHr, closeHr);
+        g.list[slot].Reset();
+        g.alloc[slot].Reset();
+        return false;
+    }
+    g.ringValue[slot] = 0;
+    return true;
+}
+
 bool CreateWorkDevice(IDXGIAdapter *adapter, LUID luid)
 {
     DXGI_ADAPTER_DESC ad {};
@@ -1608,16 +1638,11 @@ bool CreateWorkDevice(IDXGIAdapter *adapter, LUID luid)
     }
     for (UINT i = 0; i < State::kRing; ++i)
     {
-        if (FAILED(g.workDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT,
-                                                        IID_PPV_ARGS(&g.alloc[i]))) ||
-            FAILED(g.workDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT,
-                                                   g.alloc[i].Get(), nullptr,
-                                                   IID_PPV_ARGS(&g.list[i]))))
+        if (!RecreateWorkSlot(i))
         {
             Log("bridge: could not create the command allocator or list.");
             return false;
         }
-        g.list[i]->Close();
     }
     if (FAILED(g.workDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&g.ringFence))) ||
         FAILED(g.workDevice->CreateFence(0, D3D12_FENCE_FLAG_SHARED, IID_PPV_ARGS(&g.crossFence))) ||
@@ -2019,7 +2044,9 @@ void DrainReadbacks(UINT nw, UINT nh)
 }
 
 bool EnsureResources(UINT w, UINT h, DXGI_FORMAT outFormat, float scale);
-bool CreateTexture(UINT w, UINT h, DXGI_FORMAT f, ComPtr<ID3D12Resource> &out, const char *what);
+bool CreateTexture(UINT w, UINT h, DXGI_FORMAT f, ComPtr<ID3D12Resource> &out, const char *what,
+                   D3D12_RESOURCE_STATES initialState =
+                       D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
 using SubmitPassFn = std::function<bool()>;
 bool RecordNetwork(ID3D12GraphicsCommandList *&cmd, ID3D12Resource *colourSrc,
                    DXGI_FORMAT colourFmt, ID3D12Resource *outTarget, bool runNetwork, UINT wanted,
@@ -2421,7 +2448,8 @@ void BridgePresent(device *dev, swapchain *sc)
     if (g.crossLocal == nullptr || g.crossLocal->GetDesc().Width != w ||
         g.crossLocal->GetDesc().Height != h)
     {
-        if (!CreateTexture(w, h, fmt, g.crossLocal, "crossLocal"))
+        if (!CreateTexture(w, h, fmt, g.crossLocal, "crossLocal",
+                           D3D12_RESOURCE_STATE_COPY_DEST))
         {
             g.bridgeFailed = true;
             return;
@@ -2495,10 +2523,16 @@ void BridgePresent(device *dev, swapchain *sc)
     if (g.ringValue[i] != 0 &&
         !WaitFence(g.ringFence.Get(), g.ringValue[i], g.ringEvent, "the ring slot to come free"))
         return;
-    if (FAILED(g.alloc[i]->Reset()) || FAILED(g.list[i]->Reset(g.alloc[i].Get(), nullptr)))
+    const HRESULT allocatorHr = g.alloc[i]->Reset();
+    const HRESULT listHr = SUCCEEDED(allocatorHr)
+                               ? g.list[i]->Reset(g.alloc[i].Get(), nullptr)
+                               : allocatorHr;
+    if (FAILED(allocatorHr) || FAILED(listHr))
     {
-        Log("bridge: command list reset failed.");
-        g.bridgeFailed = true;
+        Log("bridge: work slot %u reset failed (allocator 0x%08lX, list 0x%08lX); "
+            "recreating the pair.", i, allocatorHr, listHr);
+        if (!RecreateWorkSlot(i))
+            g.bridgeFailed = true;
         return;
     }
     auto *cmd = g.list[i].Get();
@@ -2551,7 +2585,11 @@ void BridgePresent(device *dev, swapchain *sc)
         // add-on then returned from every present in silence and left the last image it wrote on
         // screen. Both halves of that were wrong.
         Log("bridge: closing the command list failed (0x%08lX); rebuilding.", hr);
-        g.bridgeFailed = true;
+        g.lastJob = 0;
+        g.activePasses = 0;
+        g.historyValid.store(false);
+        if (!RecreateWorkSlot(i))
+            g.bridgeFailed = true;
         return;
     }
     ID3D12CommandList *lists[] { cmd };
@@ -3012,7 +3050,8 @@ bool InitPipeline()
     return SUCCEEDED(g.device->CreateDescriptorHeap(&hd, IID_PPV_ARGS(&g.heap)));
 }
 
-bool CreateTexture(UINT w, UINT h, DXGI_FORMAT f, ComPtr<ID3D12Resource> &out, const char *what)
+bool CreateTexture(UINT w, UINT h, DXGI_FORMAT f, ComPtr<ID3D12Resource> &out, const char *what,
+                   D3D12_RESOURCE_STATES initialState)
 {
     out.Reset();
     D3D12_HEAP_PROPERTIES hp {};
@@ -3026,8 +3065,7 @@ bool CreateTexture(UINT w, UINT h, DXGI_FORMAT f, ComPtr<ID3D12Resource> &out, c
     rd.Format = f;
     rd.SampleDesc.Count = 1;
     rd.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-    if (FAILED(g.device->CreateCommittedResource(&hp, D3D12_HEAP_FLAG_NONE, &rd,
-                                                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+    if (FAILED(g.device->CreateCommittedResource(&hp, D3D12_HEAP_FLAG_NONE, &rd, initialState,
                                                  nullptr, IID_PPV_ARGS(&out))))
     {
         Log("texture creation failed: %s %ux%u format %d", what, w, h, static_cast<int>(f));
@@ -3392,9 +3430,33 @@ bool OnClearDepth(command_list *cmd_list, resource_view dsv, const float *, cons
 // Flushing per frame is not enough on its own: the documented sequence is ClearState and then
 // Flush, and ClearState is only safe here.
 // Everything sized to the swapchain, dropped together. Ensure rebuilds each one on demand.
+#if DLSS5_WITH_VULKAN
+namespace vkroute { void ReleaseSwapchainSized(); }
+#endif
+
 void ReleaseSwapchainSized()
 {
     WaitForWorkQueue(g.completion);
+#if DLSS5_WITH_VULKAN
+    // The imported VkImages have the same lifetime as the D3D12 resources below. Invalidate the
+    // route even when the replacement swapchain keeps the same size and format, otherwise its
+    // fast path returns with crossLocal already released.
+    vkroute::ReleaseSwapchainSized();
+#endif
+    // Closed command lists retain references to their recorded resources until Reset. Retire all
+    // slots while the queue is idle so no recording from the old swapchain survives the teardown.
+    if (g.workDevice != nullptr)
+    {
+        for (UINT i = 0; i < State::kRing; ++i)
+        {
+            if (RecreateWorkSlot(i))
+                continue;
+            g.bridgeFailed = true;
+            g.unavailable = true;
+            g.reason = "could not retire the D3D12 work slots during swapchain teardown";
+            break;
+        }
+    }
     g.bridgeIn.Destroy();
     g.bridgeOut.Destroy();
     g.crossLocal.Reset();

--- a/src/neural/vk_route.inc
+++ b/src/neural/vk_route.inc
@@ -336,6 +336,8 @@ struct Route
     bool ready = false;
     bool loggedReady = false;
     bool loggedFirstFrame = false;
+    bool loggedQueue = false;
+    bool loggedUnsupportedQueue = false;
 
     Api api {};
     VkDevice device = nullptr;
@@ -361,6 +363,57 @@ struct Route
 
 Route g_route;
 
+// ReShade's stock Vulkan manifest uses the _1 kill switch. DOOM Eternal's launcher sets that
+// exact variable, so the compatible global manifest on this machine uses _2. Preserve both while
+// the add-on creates its private discovery instance, otherwise that instance recursively enters
+// ReShade again.
+std::wstring SaveEnvironmentVariable(const wchar_t *name, bool &present)
+{
+    const DWORD required = GetEnvironmentVariableW(name, nullptr, 0);
+    present = required != 0;
+    if (!present)
+        return {};
+
+    std::wstring value(required, L'\0');
+    const DWORD copied = GetEnvironmentVariableW(name, value.data(), required);
+    value.resize(copied);
+    return value;
+}
+
+void RestoreEnvironmentVariable(const wchar_t *name, bool present, const std::wstring &value)
+{
+    SetEnvironmentVariableW(name, present ? value.c_str() : nullptr);
+}
+
+// The host VkDevice outlives a swapchain, but the imported images do not: they have the old
+// swapchain's size and are paired with D3D12 resources released by the common teardown. Make the
+// route visibly not ready before those resources go away, including when the replacement
+// swapchain happens to have exactly the same dimensions and format.
+void ReleaseSwapchainSized()
+{
+    Route &r = g_route;
+    r.ready = false;
+
+    if (r.device != nullptr && r.api.deviceWaitIdle != nullptr)
+    {
+        const int result = r.api.deviceWaitIdle(r.device);
+        if (result != 0)
+            Log("vulkan: vkDeviceWaitIdle during swapchain teardown returned %d.", result);
+    }
+    if (r.device != nullptr)
+    {
+        r.in.Release(r.api, r.device);
+        r.out.Release(r.api, r.device);
+    }
+
+    r.width = 0;
+    r.height = 0;
+    r.format = DXGI_FORMAT_UNKNOWN;
+    r.vkFormat = 0;
+    r.loggedReady = false;
+    r.loggedFirstFrame = false;
+}
+
 // Our own VkInstance, only ever used to reach a VkPhysicalDevice and ask it two questions: which
 // GPU is this (LUID, so the D3D12 device lands on the same one) and what memory types does it
 // have. Memory types are a property of the physical GPU and its driver, not of an instance, so
@@ -380,10 +433,18 @@ bool FindPhysicalDevice(Route &r)
     // vkCreateInstance -- so without this our private instance would re-enter ReShade's own
     // instance setup from inside its present. Its layer manifest publishes the variable that
     // turns it off, so use the documented switch rather than hoping the re-entry is harmless.
-    // Restored immediately: the host's next instance, if it makes one, must still get ReShade.
+    // Restored immediately: the host's next instance, if it makes one, must retain the exact
+    // environment it had before this callback. This matters on DOOM, where _1 is already set.
+    bool hadDisable1 = false, hadDisable2 = false;
+    const std::wstring disable1 =
+        SaveEnvironmentVariable(L"DISABLE_VK_LAYER_reshade_1", hadDisable1);
+    const std::wstring disable2 =
+        SaveEnvironmentVariable(L"DISABLE_VK_LAYER_reshade_2", hadDisable2);
     SetEnvironmentVariableW(L"DISABLE_VK_LAYER_reshade_1", L"1");
+    SetEnvironmentVariableW(L"DISABLE_VK_LAYER_reshade_2", L"1");
     const int made = r.api.createInstance(&ici, nullptr, &r.ownInstance);
-    SetEnvironmentVariableW(L"DISABLE_VK_LAYER_reshade_1", nullptr);
+    RestoreEnvironmentVariable(L"DISABLE_VK_LAYER_reshade_2", hadDisable2, disable2);
+    RestoreEnvironmentVariable(L"DISABLE_VK_LAYER_reshade_1", hadDisable1, disable1);
     if (made != 0 || r.ownInstance == nullptr)
     {
         Log("vulkan: could not create a private VkInstance to identify the GPU (VkResult %d).",
@@ -619,7 +680,8 @@ bool BuildCrossing(Route &r, Crossing &c, UINT w, UINT h, DXGI_FORMAT fmt, int v
 
 // Everything that only has to happen once, plus the resize path. Returns false with a reason
 // already logged.
-bool Ensure(Route &r, device *dev, command_queue *queue, UINT w, UINT h, DXGI_FORMAT fmt)
+bool Ensure(Route &r, device *dev, command_queue *queue, command_list *immediate, UINT w, UINT h,
+            DXGI_FORMAT fmt)
 {
     if (r.failed)
         return false;
@@ -690,8 +752,16 @@ bool Ensure(Route &r, device *dev, command_queue *queue, UINT w, UINT h, DXGI_FO
         }
     }
 
-    if (r.ready && r.width == w && r.height == h && r.format == fmt)
+    const bool crossingsReady = r.in.image != nullptr && r.in.memory != nullptr &&
+                                r.in.on12 != nullptr && r.out.image != nullptr &&
+                                r.out.memory != nullptr && r.out.on12 != nullptr;
+    if (r.ready && r.width == w && r.height == h && r.format == fmt &&
+        crossingsReady && g.crossLocal != nullptr)
         return true;
+
+    if (r.ready && r.width == w && r.height == h && r.format == fmt)
+        Log("vulkan: route was marked ready after a swapchain teardown but one or more shared "
+            "resources are gone; rebuilding it.");
 
     const int vkFmt = VkFormatFor(fmt);
     if (vkFmt == 0)
@@ -703,8 +773,7 @@ bool Ensure(Route &r, device *dev, command_queue *queue, UINT w, UINT h, DXGI_FO
     }
 
     r.ready = false;
-    auto *cmd = reinterpret_cast<VkCommandBuffer>(
-        queue->get_immediate_command_list()->get_native());
+    auto *cmd = reinterpret_cast<VkCommandBuffer>(immediate->get_native());
     if (cmd == nullptr)
     {
         r.Stop("ReShade gave no immediate command buffer.");
@@ -722,7 +791,8 @@ bool Ensure(Route &r, device *dev, command_queue *queue, UINT w, UINT h, DXGI_FO
     // Our private copy, on our device, so the network never reads a shared resource directly --
     // same reason the D3D11 route keeps crossLocal.
     g.crossLocal.Reset();
-    if (!CreateTexture(w, h, fmt, g.crossLocal, "crossLocal"))
+    if (!CreateTexture(w, h, fmt, g.crossLocal, "crossLocal",
+                       D3D12_RESOURCE_STATE_COPY_DEST))
     {
         r.Stop("could not create the private copy of the frame.");
         return false;
@@ -750,6 +820,38 @@ void Present(command_queue *queue, swapchain *sc)
     devicehook::ReportOnce();
     device *dev = sc->get_device();
 
+    const command_queue_type queueType = queue->get_type();
+    if ((queueType & command_queue_type::graphics) == static_cast<command_queue_type>(0))
+    {
+        if (!r.loggedUnsupportedQueue)
+        {
+            r.loggedUnsupportedQueue = true;
+            Log("vulkan: present arrived on a non-graphics queue (flags 0x%X). ReShade does not "
+                "provide an immediate command list for this queue, so this frame is skipped. "
+                "For DOOM Eternal, set r_presentFromAsync to 0.",
+                static_cast<unsigned>(queueType));
+        }
+        return;
+    }
+
+    command_list *immediate = queue->get_immediate_command_list();
+    if (immediate == nullptr)
+    {
+        if (!r.loggedUnsupportedQueue)
+        {
+            r.loggedUnsupportedQueue = true;
+            Log("vulkan: the graphics present queue returned no immediate command list; this "
+                "frame is skipped instead of dereferencing a null pointer.");
+        }
+        return;
+    }
+    if (!r.loggedQueue)
+    {
+        r.loggedQueue = true;
+        Log("vulkan: present queue flags 0x%X; graphics immediate command list available.",
+            static_cast<unsigned>(queueType));
+    }
+
     const resource back = sc->get_current_back_buffer();
     if (back.handle == 0)
         return;
@@ -761,7 +863,7 @@ void Present(command_queue *queue, swapchain *sc)
     // textures and compose all agree on one concrete format. A typeless swapchain is legal on the
     // D3D12 side and impossible on the Vulkan one; carrying it further would mean the two sides of
     // the same memory disagreeing about what is in it.
-    if (!Ensure(r, dev, queue, bd.texture.width, bd.texture.height,
+    if (!Ensure(r, dev, queue, immediate, bd.texture.width, bd.texture.height,
                 ColourReadFormat(static_cast<DXGI_FORMAT>(bd.texture.format))))
         return;
 
@@ -820,7 +922,7 @@ void Present(command_queue *queue, swapchain *sc)
     // ReShade's barrier() moves the host's own image, because ReShade is what knows the layout
     // it is in; the copy itself is raw Vulkan on the same command buffer.
     {
-        command_list *list = queue->get_immediate_command_list();
+        command_list *list = immediate;
         auto *cmd = reinterpret_cast<VkCommandBuffer>(list->get_native());
         if (cmd == nullptr)
             return;
@@ -839,9 +941,16 @@ void Present(command_queue *queue, swapchain *sc)
         g.ringFence->SetEventOnCompletion(g.ringValue[slot], g.ringEvent);
         WaitForSingleObject(g.ringEvent, 2000);
     }
-    if (FAILED(g.alloc[slot]->Reset()) || FAILED(g.list[slot]->Reset(g.alloc[slot].Get(), nullptr)))
+    const HRESULT allocatorHr = g.alloc[slot]->Reset();
+    const HRESULT listHr = SUCCEEDED(allocatorHr)
+                               ? g.list[slot]->Reset(g.alloc[slot].Get(), nullptr)
+                               : allocatorHr;
+    if (FAILED(allocatorHr) || FAILED(listHr))
     {
-        Log("vulkan: command list reset failed.");
+        Log("vulkan: work slot %u reset failed (allocator 0x%08lX, list 0x%08lX); "
+            "recreating the pair.", slot, allocatorHr, listHr);
+        if (!RecreateWorkSlot(slot))
+            r.Stop("the D3D12 work slot could not be recovered.");
         return;
     }
     auto *cmd12 = g.list[slot].Get();
@@ -867,9 +976,15 @@ void Present(command_queue *queue, swapchain *sc)
         Barrier(cmd12, g.composed.Get(), D3D12_RESOURCE_STATE_COPY_SOURCE,
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
     }
-    if (FAILED(cmd12->Close()))
+    if (const HRESULT hr = cmd12->Close(); FAILED(hr))
     {
-        Log("vulkan: closing the command list failed.");
+        Log("vulkan: closing work slot %u failed (0x%08lX); discarding the unsubmitted job and "
+            "recreating the pair.", slot, hr);
+        g.lastJob = 0;
+        g.activePasses = 0;
+        g.historyValid.store(false);
+        if (!RecreateWorkSlot(slot))
+            r.Stop("the D3D12 work slot could not be recovered after Close failed.");
         return;
     }
     ID3D12CommandList *lists[] { cmd12 };
@@ -886,7 +1001,7 @@ void Present(command_queue *queue, swapchain *sc)
     // --- 3. and the finished image goes back over the host's -------------------------------
     if (fresh && !g.noBackBuffer.load())
     {
-        command_list *list = queue->get_immediate_command_list();
+        command_list *list = immediate;
         auto *cmd = reinterpret_cast<VkCommandBuffer>(list->get_native());
         if (cmd != nullptr)
         {


### PR DESCRIPTION
- statically link the CRT for packaged game compatibility
- validate graphics present queues and recover poisoned work slots
- rebuild Vulkan crossings across swapchain teardown
- Document the v0.4.1 lifecycle fixes and live validation, expand the Vulkan setup and troubleshooting guidance, and mark the pre-unified preview as historical.